### PR TITLE
feat(denovo): add post-hoc K-W tests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3564,6 +3564,28 @@ examples = ["matplotlib (>=3.3.4)", "pandas (>=1.1.5)", "plotly (>=5.14.0)", "po
 tests = ["black (>=23.3.0)", "matplotlib (>=3.3.4)", "mypy (>=1.3)", "numpydoc (>=1.2.0)", "pandas (>=1.1.5)", "polars (>=0.19.12)", "pooch (>=1.6.0)", "pyamg (>=4.0.0)", "pyarrow (>=12.0.0)", "pytest (>=7.1.2)", "pytest-cov (>=2.9.0)", "ruff (>=0.0.272)", "scikit-image (>=0.17.2)"]
 
 [[package]]
+name = "scikit-posthocs"
+version = "0.9.0"
+description = "Statistical post-hoc analysis and outlier detection algorithms"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "scikit-posthocs-0.9.0.tar.gz", hash = "sha256:61a670d5ebcfb52e93beef0a8d7ff0260fd803d2e36fcd97492e64909890dd71"},
+    {file = "scikit_posthocs-0.9.0-py3-none-any.whl", hash = "sha256:86772d3b049b9879569446f134b00410ca7d2607ffc7ea940bbc869a7a3c3410"},
+]
+
+[package.dependencies]
+matplotlib = "*"
+numpy = "*"
+pandas = ">=0.20.0"
+scipy = ">=1.9.0"
+seaborn = "*"
+statsmodels = "*"
+
+[package.extras]
+test = ["coverage", "pytest"]
+
+[[package]]
 name = "scipy"
 version = "1.12.0"
 description = "Fundamental algorithms for scientific computing in Python"
@@ -4388,4 +4410,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "25728c67e65d01ca3cae87491d1d2847e438cbe6a6b15724839371fb0db6c219"
+content-hash = "de81e480480d3ec83188eaec2f5dfd98f1ae550feb95a25051d16cda3c991f70"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ scikit-bio = "^0.6.0"
 kneed = "^0.8.5"
 marsilea = "^0.4.3"
 multimethod = "^1.12"
+scikit-posthocs = "^0.9.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/tests/test_denovo.py
+++ b/tests/test_denovo.py
@@ -1014,6 +1014,9 @@ def test_univariate_tests(small_decomposition):
         "Incorrect direction indicated by mean."
     assert (test_too['signature'] == test_too['max_median']).all(), \
         "Incorrect direction indicated by median."
+    assert (test_too[['signature', 'posthoc_str']].apply(
+        lambda x: x.iloc[1].count(x.iloc[0]), axis=1
+    ) == 2).all(), "Some post-hoc tests not significant when should be."
 
 def test_plot_metadata(
         small_decomposition,


### PR DESCRIPTION
Added post-hoc testing using Dunn's test to the `univariate_tests` method. This information is not yet displayed in the default plots.